### PR TITLE
Added information on new Qt port.

### DIFF
--- a/docs/scenarios/gui.rst
+++ b/docs/scenarios/gui.rst
@@ -92,7 +92,7 @@ non-GUI applications.
 
 PySimpleGUI 
 ------  
-`PySimpleGUI <https://pysimplegui.readthedocs.io/>`_ is a  wrapper for the Tkinter.  The amount of code required to implement custom GUIs is much shorter using PySimpleGUI than if the same GUI were written directly using tkinter.  Having Tkinter as a base results in the ability to run on a larger number of platforms than other GUI frameworks.
+`PySimpleGUI <https://pysimplegui.readthedocs.io/>`_ is a  wrapper for Tkinter and Qt (others on the way).  The amount of code required to implement custom GUIs is much shorter using PySimpleGUI than if the same GUI were written directly using tkinter or Qt.  PySimpleGUI code can be "ported" between GUI frameworks by changing import statement.
 
 .. code-block:: console 
 


### PR DESCRIPTION
Since PySimpleGUI now support Qt, I'm finding it important to change all the places on the net that show PySimpleGUI is a tkinter only solution.  Also want to indicate that other ports are underway (Wx was started) to leave room for the future without having to come back every time.
