### PR TITLE
Style it "Xcode", not "XCode"

### DIFF
--- a/docs/scenarios/gui.rst
+++ b/docs/scenarios/gui.rst
@@ -64,7 +64,7 @@ such as: Mouse, Dual Mouse, TUIO, WiiMote, WM_TOUCH, HIDtouch, Apple's products
 and so on.
 
 Kivy is actively being developed by a community and is free to use. It operates
-on all major platforms (Linux, OSX, Windows, Android).
+on all major platforms (Linux, OS X, Windows, Android).
 
 The main resource for information is the website: http://kivy.org
 
@@ -124,12 +124,12 @@ non-GUI applications.
 
 
 ***********
-PySimpleGUI 
+PySimpleGUI
 ***********
 
 `PySimpleGUI <https://pysimplegui.readthedocs.io/>`_ is a  wrapper for Tkinter and Qt (others on the way).  The amount of code required to implement custom GUIs is much shorter using PySimpleGUI than if the same GUI were written directly using tkinter or Qt.  PySimpleGUI code can be "ported" between GUI frameworks by changing import statement.
 
-.. code-block:: console 
+.. code-block:: console
 
   $ pip install pysimplegui
 

--- a/docs/shipping/packaging.rst
+++ b/docs/shipping/packaging.rst
@@ -168,10 +168,10 @@ each distribution's format (e.g. .deb for Debian/Ubuntu, .rpm for Red
 Hat/Fedora, etc) is a fair amount of work. If your code is an application that
 you plan to distribute on other platforms, then you'll also have to create and
 maintain the separate config required to freeze your application for Windows
-and OSX. It would be much less work to simply create and maintain a single
+and OS X. It would be much less work to simply create and maintain a single
 config for one of the cross platform :ref:`freezing tools
 <freezing-your-code-ref>`, which will produce stand-alone executables for all
-distributions of Linux, as well as Windows and OSX.
+distributions of Linux, as well as Windows and OS X.
 
 Creating a distribution package is also problematic if your code is for a
 version of Python that isn't currently supported by a distribution.

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -39,12 +39,12 @@ minimal but unofficial
 package.
 
 .. note::
-    If you already have XCode installed, do not install OSX-GCC-Installer.
+    If you already have Xcode installed, do not install OSX-GCC-Installer.
     In combination, the software can cause issues that are difficult to
     diagnose.
 
 .. note::
-    If you perform a fresh install of XCode, you will also need to add the
+    If you perform a fresh install of Xcode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 
@@ -53,7 +53,7 @@ Linux systems will notice one key component missing: a decent package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
 To `install Homebrew <http://brew.sh/#install>`_, open :file:`Terminal` or
-your favorite OSX terminal emulator and run
+your favorite OS X terminal emulator and run
 
 .. code-block:: console
 

--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -27,18 +27,18 @@ Doing it Right
 Let's install a real version of Python.
 
 Before installing Python, you'll need to install GCC. GCC can be obtained
-by downloading `XCode <http://developer.apple.com/xcode/>`_, the smaller
+by downloading `Xcode <http://developer.apple.com/xcode/>`_, the smaller
 `Command Line Tools <https://developer.apple.com/downloads/>`_ (must have an
 Apple account) or the even smaller `OSX-GCC-Installer <https://github.com/kennethreitz/osx-gcc-installer#readme>`_
 package.
 
 .. note::
-    If you already have XCode installed, do not install OSX-GCC-Installer.
+    If you already have Xcode installed, do not install OSX-GCC-Installer.
     In combination, the software can cause issues that are difficult to
     diagnose.
 
 .. note::
-    If you perform a fresh install of XCode, you will also need to add the
+    If you perform a fresh install of Xcode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 While OS X comes with a large number of UNIX utilities, those familiar with
@@ -46,7 +46,7 @@ Linux systems will notice one key component missing: a package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
 To `install Homebrew <http://brew.sh/#install>`_, open :file:`Terminal` or
-your favorite OSX terminal emulator and run
+your favorite OS X terminal emulator and run
 
 .. code-block:: console
 

--- a/docs/starting/install3/win.rst
+++ b/docs/starting/install3/win.rst
@@ -8,7 +8,7 @@ Installing Python 3 on Windows
 .. image:: /_static/photos/34435689480_2e6f358510_k_d.jpg
 
 First, follow the installation instructions for `Chocolatey <https://chocolatey.org/install>`_.
-It's a community system packager manager for Windows 7+. (It's very much like Homebrew on OSX.)
+It's a community system packager manager for Windows 7+. (It's very much like Homebrew on OS X.)
 
 Once done, installing Python 3 is very simple, because Chocolatey pushes Python 3 as the default.
 


### PR DESCRIPTION
Apple styles it as "Xcode" with a lower-case "c". This PR updates the OS X installation section to consistently use "Xcode" instead of "Code". Also fixes a couple "OSX"s with missing spaces.