### PR TITLE
Re-style "OS X" as "macOS" to match Apple's new branding.

### DIFF
--- a/docs/contents.rst.inc
+++ b/docs/contents.rst.inc
@@ -14,10 +14,10 @@ New to Python? Let's properly setup up your Python environment:
     :maxdepth: 1
 
     starting/installation
-    starting/install3/osx
+    starting/install3/macos
     starting/install3/win
     starting/install3/linux
-    starting/install/osx
+    starting/install/macos
     starting/install/win
     starting/install/linux
 
@@ -137,8 +137,3 @@ Contribution notes and legal information (for those interested).
    notes/contribute
    notes/license
    notes/styleguide
-
-
-
-
-

--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -211,7 +211,7 @@ NINJA-IDE
 
 `NINJA-IDE <http://www.ninja-ide.org/>`_ (from the recursive acronym: "Ninja-IDE
 Is Not Just Another IDE") is a cross-platform IDE, specially designed to build
-Python applications, and runs on Linux/X11, Mac OS X and Windows desktop
+Python applications, and runs on Linux/X11, macOS and Windows desktop
 operating systems. Installers for these platforms can be downloaded from the
 website.
 

--- a/docs/dev/pip-virtualenv.rst
+++ b/docs/dev/pip-virtualenv.rst
@@ -39,7 +39,7 @@ environment is needed to install packages.
     Could not find an activated virtualenv (required).
 
 You can also do this configuration by editing your :file:`pip.conf` or
-:file:`pip.ini` file. :file:`pip.conf` is used by Unix and Mac OS X operating
+:file:`pip.ini` file. :file:`pip.conf` is used by Unix and macOS operating
 systems and it can be found at:
 
 .. code-block:: console

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -418,7 +418,7 @@ autoenv
 When you ``cd`` into a directory containing a :file:`.env`, `autoenv <https://github.com/kennethreitz/autoenv>`_
 automagically activates the environment.
 
-Install it on Mac OS X using ``brew``:
+Install it on macOS using ``brew``:
 
 .. code-block:: console
 

--- a/docs/scenarios/gui.rst
+++ b/docs/scenarios/gui.rst
@@ -26,7 +26,7 @@ and the mailing list https://groups.google.com/forum/#!forum/project-camelot
 Cocoa
 *****
 
-.. note:: The Cocoa framework is only available on OS X. Don't pick this if you're writing a cross-platform application!
+.. note:: The Cocoa framework is only available on macOS. Don't pick this if you're writing a cross-platform application!
 
 
 ***

--- a/docs/shipping/freezing.rst
+++ b/docs/shipping/freezing.rst
@@ -16,7 +16,7 @@ BitTorrent clients do this.
 
 The advantage of distributing this way is that your application will "just work",
 even if the user doesn't already have the required version of Python (or any)
-installed. On Windows, and even on many Linux distributions and OS X, the right
+installed. On Windows, and even on many Linux distributions and macOS, the right
 version of Python will not already be installed.
 
 Besides, end-user software should always be in an executable format. Files
@@ -49,7 +49,7 @@ Comparison of Freezing Tools
 Solutions and platforms/features supported:
 
 =========== ======= ===== ==== ======== ======= ============= ============== ==== =====================
-Solution    Windows Linux OS X Python 3 License One-file mode Zipfile import Eggs pkg_resources support
+Solution    Windows Linux macOS Python 3 License One-file mode Zipfile import Eggs pkg_resources support
 =========== ======= ===== ==== ======== ======= ============= ============== ==== =====================
 bbFreeze    yes     yes   yes  no       MIT     no            yes            yes  yes
 py2exe      yes     no    no   yes      MIT     yes           yes            no   no
@@ -159,7 +159,7 @@ Prerequisite is to have installed :ref:`Python, Setuptools and pywin32 dependenc
 
 
 ****
-OS X
+macOS
 ****
 
 
@@ -169,7 +169,7 @@ py2app
 PyInstaller
 ~~~~~~~~~~~
 
-PyInstaller can be used to build Unix executables and windowed apps on Mac OS X 10.6 (Snow Leopard) or newer.
+PyInstaller can be used to build Unix executables and windowed apps on macOS 10.6 (Snow Leopard) or newer.
 
 To install PyInstaller, use pip:
 
@@ -203,7 +203,7 @@ Now :code:`script.spec` can be run with :code:`pyinstaller` (instead of using :c
 
   $ pyinstaller script.spec
 
-To create a standalone windowed OS X application, use the :code:`--windowed` option
+To create a standalone windowed macOS application, use the :code:`--windowed` option
 
 .. code-block:: console
 
@@ -211,7 +211,7 @@ To create a standalone windowed OS X application, use the :code:`--windowed` opt
 
 This creates a :code:`script.app` in the :code:`dist` folder. Make sure to use GUI packages in your Python code, like `PyQt <https://riverbankcomputing.com/software/pyqt/intro>`_ or `PySide <http://wiki.qt.io/About-PySide>`_, to control the graphical parts of the app.
 
-There are several options in :code:`script.spec` related to Mac OS X app bundles `here <http://pythonhosted.org/PyInstaller/spec-files.html#spec-file-options-for-a-mac-os-x-bundle>`_. For example, to specify an icon for the app, use the :code:`icon=\path\to\icon.icns` option.
+There are several options in :code:`script.spec` related to macOS app bundles `here <http://pythonhosted.org/PyInstaller/spec-files.html#spec-file-options-for-a-mac-os-x-bundle>`_. For example, to specify an icon for the app, use the :code:`icon=\path\to\icon.icns` option.
 
 
 *****

--- a/docs/starting/install/macos.rst
+++ b/docs/starting/install/macos.rst
@@ -1,16 +1,16 @@
-.. _install-osx:
+.. _install-macos:
 
 
 ###############################
-Installing Python 2 on Mac OS X
+Installing Python 2 on macOS
 ###############################
 
 .. image:: /_static/photos/34435688560_4cc2a7bcbb_k_d.jpg
 
 .. note::
-    Check out our :ref:`guide for installing Python 3 on OS X<install3-osx>`.
+    Check out our :ref:`guide for installing Python 3 on macOS<install3-macos>`.
 
-The latest version of Mac OS X, High Sierra, **comes with Python 2.7 out of the box**.
+The latest version of macOS, High Sierra, **comes with Python 2.7 out of the box**.
 
 You do not need to install or configure anything else to use Python. Having said
 that, I would strongly recommend that you install the tools and libraries
@@ -18,8 +18,8 @@ described in the next section before you start building Python applications for
 real-world use. In particular, you should always install Setuptools, as it makes
 it much easier for you to install and manage other third-party Python libraries.
 
-The version of Python that ships with OS X is great for learning, but it's not
-good for development. The version shipped with OS X may be out of date from the
+The version of Python that ships with macOS is great for learning, but it's not
+good for development. The version shipped with macOS may be out of date from the
 `official current Python release <https://www.python.org/downloads/mac-osx/>`_,
 which is considered the stable production version.
 
@@ -48,7 +48,7 @@ package.
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 
-While OS X comes with a large number of UNIX utilities, those familiar with
+While macOS comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a decent package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 

--- a/docs/starting/install3/macos.rst
+++ b/docs/starting/install3/macos.rst
@@ -1,21 +1,21 @@
 :orphan: This article should not be added to a toctree for now
 
-.. _install3-osx:
+.. _install3-macos:
 
 
 ###############################
-Installing Python 3 on Mac OS X
+Installing Python 3 on macOS
 ###############################
 
 .. image:: /_static/photos/34435689480_2e6f358510_k_d.jpg
 
-The latest version of Mac OS X, High Sierra, **comes with Python 2.7 out of the box**.
+The latest version of macOS, High Sierra, **comes with Python 2.7 out of the box**.
 
 You do not need to install or configure anything else to use Python 2. These
 instructions document the installation of Python 3.
 
-The version of Python that ships with OS X is great for learning, but it's not
-good for development. The version shipped with OS X may be out of date from the
+The version of Python that ships with macOS is great for learning, but it's not
+good for development. The version shipped with macOS may be out of date from the
 `official current Python release <https://www.python.org/downloads/mac-osx/>`_,
 which is considered the stable production version.
 
@@ -41,7 +41,7 @@ package.
     If you perform a fresh install of XCode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
-While OS X comes with a large number of UNIX utilities, those familiar with
+While macOS comes with a large number of UNIX utilities, those familiar with
 Linux systems will notice one key component missing: a package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 
@@ -62,7 +62,7 @@ line at the bottom of your :file:`~/.profile` file
 
     export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
-If you have OS X 10.12 (Sierra) or older use this line instead
+If you have macOS 10.12 (Sierra) or older use this line instead
 
 .. code-block:: console
 
@@ -88,7 +88,7 @@ Working with Python 3
 *********************
 
 At this point, you have the system Python 2.7 available, potentially the
-:ref:`Homebrew version of Python 2 <install-osx>` installed, and the Homebrew
+:ref:`Homebrew version of Python 2 <install-macos>` installed, and the Homebrew
 version of Python 3 as well.
 
 .. code-block:: console

--- a/docs/starting/installation.rst
+++ b/docs/starting/installation.rst
@@ -29,13 +29,13 @@ for development purposes, as well as setuptools, pip and virtualenv.
 Python 3 Installation Guides
 ////////////////////////////
 
-- :ref:`Python 3 on MacOS <install3-osx>`.
+- :ref:`Python 3 on MacOS <install3-macos>`.
 - :ref:`Python 3 on Windows <install3-windows>`.
 - :ref:`Python 3 on Linux <install3-linux>`.
 
 Legacy Python 2 Installation Guides
 ///////////////////////////////////
 
-- :ref:`Python 2 on MacOS <install-osx>`.
+- :ref:`Python 2 on MacOS <install-macos>`.
 - :ref:`Python 2 on Microsoft Windows <install-windows>`.
 - :ref:`Python 2 on Linux <install-linux>`.

--- a/docs/starting/which-python.rst
+++ b/docs/starting/which-python.rst
@@ -147,7 +147,7 @@ inverse approach to that taken by IronPython (see above), to which it
 is more complementary than competing with.
 
 In conjunction with Mono, pythonnet enables native Python
-installations on non-Windows operating systems, such as OS X and
+installations on non-Windows operating systems, such as macOS and
 Linux, to operate within the .NET framework.  It can be run in
 addition to IronPython without conflict.
 


### PR DESCRIPTION
Apple has renamed "OS X" to "macOS". Want to update the guide to match?