### PR TITLE
Update Anaconda links and text to reflect company name change

### DIFF
--- a/docs/scenarios/scientific.rst
+++ b/docs/scenarios/scientific.rst
@@ -140,11 +140,10 @@ out.
 Anaconda
 --------
 
-`Continuum Analytics <http://continuum.io/>`_ offers the `Anaconda
-Python Distribution <https://store.continuum.io/cshop/anaconda>`_ which
+The `Anaconda Python Distribution <https://www.anaconda.com/>`_
 includes all the common scientific Python packages as well as many packages
-related to data analytics and big data. Anaconda itself is free, and
-Continuum sells a number of proprietary add-ons. Free licenses for the
+related to data analytics and big data. Anaconda itself is free, and a number
+of proprietary add-ons are available for a fee. Free licenses for the
 add-ons are available for academics and researchers.
 
 Canopy


### PR DESCRIPTION
This PR updates the Anaconda description and links to reflect the fact that Continuum Analytics has changed its name to Anaconda.

https://www.anaconda.com/blog/company-blog/continuum-analytics-officially-becomes-anaconda/