### PR TITLE
Use "Unix" instead of "UNIX" consistently

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -109,7 +109,7 @@ TextMate
 --------
 
     `TextMate <http://macromates.com/>`_ brings Apple's approach to operating
-    systems into the world of text editors. By bridging UNIX underpinnings and
+    systems into the world of text editors. By bridging Unix underpinnings and
     GUI, TextMate cherry-picks the best of both worlds to the benefit of expert
     scripters and novice users alike.
 

--- a/docs/dev/pip-virtualenv.rst
+++ b/docs/dev/pip-virtualenv.rst
@@ -105,7 +105,7 @@ need any configuration.
 When using older versions, you can configure pip in such a way that it tries to
 reuse already installed packages, too.
 
-On UNIX systems, you can add the following line to your :file:`.bashrc` or
+On Unix systems, you can add the following line to your :file:`.bashrc` or
 :file:`.bash_profile` file.
 
 .. code-block:: console
@@ -124,7 +124,7 @@ add the following line to your :file:`pip.ini` file under ``[global]`` settings:
 
     download-cache = %HOME%\pip\cache
 
-Similarly, on UNIX systems you should simply add the following line to your
+Similarly, on Unix systems you should simply add the following line to your
 :file:`pip.conf` file under ``[global]`` settings:
 
 .. code-block:: console

--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -48,7 +48,7 @@ package.
     commandline tools by running ``xcode-select --install`` on the terminal.
 
 
-While OS X comes with a large number of UNIX utilities, those familiar with
+While OS X comes with a large number of Unix utilities, those familiar with
 Linux systems will notice one key component missing: a decent package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 

--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -41,7 +41,7 @@ package.
     If you perform a fresh install of Xcode, you will also need to add the
     commandline tools by running ``xcode-select --install`` on the terminal.
 
-While OS X comes with a large number of UNIX utilities, those familiar with
+While OS X comes with a large number of Unix utilities, those familiar with
 Linux systems will notice one key component missing: a package manager.
 `Homebrew <http://brew.sh>`_ fills this void.
 


### PR DESCRIPTION
The Guide currently uses a mix of "Unix" and "UNIX" stylings. This PR makes them all "Unix", which seems to be the more modern usage.