### PR TITLE
Format Windows console examples with `doscon`or `powershell`

### DIFF
--- a/docs/notes/styleguide.rst
+++ b/docs/notes/styleguide.rst
@@ -109,7 +109,10 @@ Command line examples:
         $ run command --help
         $ ls ..
 
-Be sure to include the ``$`` prefix before each line.
+Be sure to include the ``$`` prefix before each line for Unix console examples.
+
+For Windows console examples, use ``doscon`` or ``powershell`` instead of
+``console``, and omit the ``$`` prefix.
 
 Python interpreter examples:
 

--- a/docs/starting/install/win.rst
+++ b/docs/starting/install/win.rst
@@ -32,13 +32,13 @@ tedious, so add the directories for your default Python version to the :envvar:`
 Assuming that your Python installation is in :file:`C:\\Python27\\`, add this to your
 :envvar:`PATH`:
 
-.. code-block:: console
+.. code-block:: doscon
 
     C:\Python27\;C:\Python27\Scripts\
 
 You can do this easily by running the following in ``powershell``:
 
-.. code-block:: console
+.. code-block:: powershell
 
     [Environment]::SetEnvironmentVariable("Path", "$env:Path;C:\Python27\;C:\Python27\Scripts\", "User")
 
@@ -68,9 +68,9 @@ pip by default.
 
 To see if pip is installed, open a command prompt and run
 
-.. code-block:: console
+.. code-block:: doscon
 
-    $ command -v pip
+    command -v pip
 
 To install pip, `follow the official pip installation guide <https://pip.pypa.io/en/latest/installing/>`_ - this will automatically install the latest version of setuptools.
 

--- a/docs/starting/install3/win.rst
+++ b/docs/starting/install3/win.rst
@@ -12,7 +12,7 @@ It's a community system packager manager for Windows 7+. (It's very much like Ho
 
 Once done, installing Python 3 is very simple, because Chocolatey pushes Python 3 as the default.
 
-.. code-block:: console
+.. code-block:: doscon
 
     choco install python
 
@@ -29,7 +29,9 @@ which let you download, install and uninstall any compliant Python software
 product with a single command. It also enables you to add this network installation
 capability to your own Python software with very little work.
 
-All supported versions of Python 3 include pip, so just make sure it's up to date::
+All supported versions of Python 3 include pip, so just make sure it's up to date:
+
+.. code-block:: doscon
 
     python -m pip install -U pip
 


### PR DESCRIPTION
The Windows console code blocks are formatted with the `doscon` Pygments lexer. That's the Unix console. How about formatting them with the Windows-specific `doscon` and `powershell` lexers?