### PR TITLE
Don't qualify OS X version when saying what Python version it ships with

### DIFF
--- a/docs/starting/install/osx.rst
+++ b/docs/starting/install/osx.rst
@@ -10,7 +10,7 @@ Installing Python 2 on Mac OS X
 .. note::
     Check out our :ref:`guide for installing Python 3 on OS X<install3-osx>`.
 
-The latest version of Mac OS X, High Sierra, **comes with Python 2.7 out of the box**.
+**Mac OS X comes with Python 2.7 out of the box.**
 
 You do not need to install or configure anything else to use Python. Having said
 that, I would strongly recommend that you install the tools and libraries

--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -9,7 +9,7 @@ Installing Python 3 on Mac OS X
 
 .. image:: /_static/photos/34435689480_2e6f358510_k_d.jpg
 
-The latest version of Mac OS X, High Sierra, **comes with Python 2.7 out of the box**.
+**Mac OS X comes with Python 2.7 out of the box.**
 
 You do not need to install or configure anything else to use Python 2. These
 instructions document the installation of Python 3.


### PR DESCRIPTION
The Installing on OS X sections say this:

> The latest version of Mac OS X, High Sierra, comes with Python 2.7 out of the box.

There's probably no need to qualify that statement with "High Sierra". OS X has shipped with 2.7 at least as far back as 10.7 Lion from 2011.