### PR TITLE
Standardize on American English for the Guide

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -252,7 +252,7 @@ pyenv
 of the Python interpreter to be installed at the same time.  This solves the
 problem of having different projects requiring different versions of Python.
 For example, it becomes very easy to install Python 2.7 for compatibility in
-one project, whilst still using Python 3.4 as the default interpreter.
+one project, while still using Python 3.4 as the default interpreter.
 pyenv isn't just limited to the CPython versions - it will also install PyPy,
 anaconda, miniconda, stackless, jython, and ironpython interpreters.
 

--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -151,7 +151,7 @@ Python Koans
 ~~~~~~~~~~~~
 
 Python Koans is a port of Edgecase's Ruby Koans.  It uses a test-driven
-approach, q.v. TEST DRIVEN DESIGN SECTION to provide an interactive tutorial
+approach to provide an interactive tutorial
 teaching basic Python concepts.  By fixing assertion statements that fail in a
 test script, this provides sequential steps to learning Python.
 
@@ -179,7 +179,7 @@ no previous programming experience.
 Learn to Program in Python with Codeacademy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A Codeacademy course for the absolute Python beginner. This free and interactive course provides and teaches the basics (and beyond) of Python programming whilst testing the user's knowledge in between progress.
+A Codeacademy course for the absolute Python beginner. This free and interactive course provides and teaches the basics (and beyond) of Python programming while testing the user's knowledge in between progress.
 This course also features a built-in interpreter for receiving instant feedback on your learning.
 
     `Learn to Program in Python with Codeacademy <http://www.codecademy.com/en/tracks/python>`_

--- a/docs/notes/styleguide.rst
+++ b/docs/notes/styleguide.rst
@@ -84,6 +84,8 @@ Wrap text lines at 78 characters. Where necessary, lines may exceed 78
 characters, especially if wrapping would make the source text more difficult
 to read.
 
+Use Standard American English, not British English.
+
 Use of the `serial comma <https://en.wikipedia.org/wiki/Serial_comma>`_
 (also known as the Oxford comma) is 100% non-optional. Any attempt to
 submit content with a missing serial comma will result in permanent banishment
@@ -209,4 +211,3 @@ documents or large incomplete sections.
     .. todo::
         Learn the Ultimate Answer to the Ultimate Question
         of Life, The Universe, and Everything
-

--- a/docs/writing/documentation.rst
+++ b/docs/writing/documentation.rst
@@ -182,7 +182,7 @@ comment block is a programmer's note. The docstring describes the
 
 Unlike block comments, docstrings are built into the Python language itself.
 This means you can use all of Python's powerful introspection capabilities to
-access docstrings at runtime, compared with comments which are optimised out.
+access docstrings at runtime, compared with comments which are optimized out.
 Docstrings are accessible from both the `__doc__` dunder attribute for almost
 every Python object, as well as with the built in `help()` function.
 


### PR DESCRIPTION
Fixes https://github.com/realpython/python-guide/issues/838

Standardizes on American English by adding a note in the Guide Style Guide and converting a couple Britishisms to American usage.