### PR TITLE
python-requests.org redirect

### DIFF
--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -156,7 +156,7 @@ when you share your project with others. You should get output similar to this
     Adding requests to Pipfile's [packages]...
     P.S. You have excellent taste! ✨ 🍰 ✨
 
-.. _Requests: http://python-requests.org
+.. _Requests: http://docs.python-requests.org/en/master/
 
 
 Using installed packages


### PR DESCRIPTION
Before, http://python-requests.org would redirect to http://docs.python-requests.org/en/master/

Now, page links to http://docs.python-requests.org/en/master/ directly.