### PR TITLE
Add link to the original essay

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -60,7 +60,7 @@ it is important.
 Sample Repository
 :::::::::::::::::
 
-**tl;dr**: This is what `Kenneth Reitz <http://kennethreitz.org>`_ recommends.
+**tl;dr**: This is what `Kenneth Reitz recommended in 2013<https://www.kennethreitz.org/essays/repository-structure-and-python>`.
 
 This repository is `available on
 GitHub <https://github.com/kennethreitz/samplemod>`__.


### PR DESCRIPTION
Adding a link to the original essay. I think it's important to add the data of the recommendation as well since a lot of things happened since then. I guess the need to add the date is pointing out that the section could need a refresh.