### PR TITLE
Fix broken reference to Stack Overflow post

### DIFF
--- a/docs/scenarios/speed.rst
+++ b/docs/scenarios/speed.rst
@@ -456,6 +456,6 @@ Multiprocessing
 .. _`concurrent.futures`: https://docs.python.org/3/library/concurrent.futures.html
 .. _`Future`: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future
 .. _`threading`: https://docs.python.org/3/library/threading.html
-.. _`stackoverflow post`: https://stackoverflow.com/questions/26688424/python-threads-are-printing-at-the-same-time-messing-up-the-text-output
+.. _`Stack Overflow post`: https://stackoverflow.com/questions/26688424/python-threads-are-printing-at-the-same-time-messing-up-the-text-output
 .. _`data race`: https://en.wikipedia.org/wiki/Race_condition
 .. _`Lock`: https://docs.python.org/3/library/threading.html#lock-objects


### PR DESCRIPTION
This fixes the following build warning:

    python-guide/docs/scenarios/speed.rst:397: WARNING: Unknown target name: "stack overflow post".