### PR TITLE
Adding pugsql to the database guide

### DIFF
--- a/docs/scenarios/db.rst
+++ b/docs/scenarios/db.rst
@@ -48,6 +48,19 @@ programmatically or exported to a number of useful data formats.
 Also included is a command-line tool for exporting SQL data.
 
 
+******
+PugSQL
+******
+
+`PugSQL <https://pugsql.org>`_ is a simple Python interface for organizing
+and using parameterized, handwritten SQL. It is an anti-ORM that is
+philosophically lo-fi, but it still presents a clean interface in Python.
+
+.. code-block:: console
+
+    $ pip install pugsql
+
+
 **********
 Django ORM
 **********


### PR DESCRIPTION
Hey, I wondered if I could talk you into including [PugSQL](https://pugsql.org). 

It's a Python take on the popular [HugSQL](https://www.hugsql.org/) Clojure library, and I've been taking pains to make it well documented. 

There wasn't any obvious order to the list that I could discern, so I stuck it underneath `Records`. It's philosophically closest to `Records`, and `Records` got there first. 

I tested my changes locally and they look fine:
![image](https://user-images.githubusercontent.com/147804/58601214-b94d2480-823c-11e9-9e82-3dbba25c38d2.png)

And I'm pretty sure I followed everything in the style guide.