### PR TITLE
Use PY3 http.server instead of SimpleHTTPServer

### DIFF
--- a/docs/shipping/packaging.rst
+++ b/docs/shipping/packaging.rst
@@ -83,7 +83,7 @@ Go to your command prompt and type:
 .. code-block:: console
 
    $ cd archive
-   $ python -m SimpleHTTPServer 9000
+   $ python -m http.server 9000
 
 This runs a simple HTTP server running on port 9000 and will list all packages
 (like **MyPackage**). Now you can install **MyPackage** using any Python


### PR DESCRIPTION
In the sample local web-server to serve packages, the command-line has been adapted to Python-3,
Python-2 module `SimpleHTTPServer` has moved to `http.server`. 