### PR TITLE
use brevity to improve readability

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 .. meta::
-   :description: An opinionated guide to the Python programming language and a best practice handbook to the installation, configuration, and usage of Python on a daily basis.
+   :description: An opinionated guide to the Python programming language and a best practice handbook to the installation, configuration, and daily use of Python.
 
 
 #################################
@@ -18,14 +18,14 @@ Greetings, Earthling! Welcome to The Hitchhiker's Guide to Python.
 
 This handcrafted guide exists to provide both novice and expert Python
 developers a best practice handbook to the installation, configuration, and
-usage of Python on a daily basis.
+daily use of Python.
 
 This guide is **opinionated** in a way that is almost, but not quite, entirely
 *unlike* Python's official documentation. You won't find a list of every Python web framework
-available here. Rather, you'll find a nice concise list of highly recommended
+available here. Rather, you'll find a concise list of highly recommended
 options.
 
-.. note:: The use of **Python 3** is *highly* preferred over Python 2. Consider upgrading your applications and infrastructure if you find yourself *still* using Python 2 in production today. If you are using Python 3, congratulations — you are indeed a person of excellent taste.
+.. note:: The use of **Python 3** is *highly* preferred to Python 2. Consider upgrading your applications and infrastructure if you find yourself *still* using Python 2 in production today. If you are using Python 3, congratulations — you are indeed a person of excellent taste.
   —*Kenneth Reitz*
 
 Let's get started! But first, let's make sure you know where your towel is.


### PR DESCRIPTION
The guide has become rather difficult to read at places. This is an attempt to improve its readability.  I believe you meant `use` and not `usage` (these words mean different things) and I have gone ahead with the suggestion to use the word `use` here. If you indeed meant `usage`, then I am afraid, that sentence _should be_ reworded.

Also, the sentence `This guide is opinionated in a way that is almost, but not quite, entirely unlike Python’s official documentation.` is also unnecessarily complicated (the placement of comma makes it even harder to understand). But I will leave it out of this commit.
