### PR TITLE
Added lines 123 to 127

### DIFF
--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -120,6 +120,12 @@ The rest of the guide will assume that ``python`` references Python 3.
     $ python --version
     Python 3.7.1 # Success!
 
+If your ``pip`` still point to Python 2 then you add these line to .bash_profile file
+
+.. code-block:: console
+
+    alias python="python3" # to use Python 3 rather than Python 2
+
 
 *****************************
 Pipenv & Virtual Environments


### PR DESCRIPTION
I was installing Python today with this tutorial and after instaling Python, python --version still pointed to Python 2. I added an alias to my .bash_profile file to point it to Python 3.