### PR TITLE
Fixed link to non-existing pep20_by_example.pdf

### DIFF
--- a/docs/writing/style.rst
+++ b/docs/writing/style.rst
@@ -455,7 +455,7 @@ Also known as :pep:`20`, the guiding principles for Python's design.
     Namespaces are one honking great idea -- let's do more of those!
 
 For some examples of good Python style, see `these slides from a Python user
-group <http://artifex.org/~hblanks/talks/2011/pep20_by_example.pdf>`_.
+group <https://github.com/hblanks/zen-of-python-by-example>`_.
 
 
 *****


### PR DESCRIPTION
The link to the pep20_by_example.pdf is wrong and points to a 404 page. I have replaced the old link with a new link pointing to the Github repo from the creator of the original presentation. I did not link explicitly the pdf in the repo, to allow the visitors to see more content.