### PR TITLE
Fix variable name for specifying interpreter

### DIFF
--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -251,7 +251,7 @@ or change the interpreter globally with an env variable in ``~/.bashrc``:
 
 .. code-block:: console
 
-   $ export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python2.7
+   $ export VIRTUALENV_PYTHON=/usr/bin/python2.7
 
 2. To begin using the virtual environment, it needs to be activated:
 


### PR DESCRIPTION
Using `VIRTUALENVWRAPPER_PYTHON` won't work at this point, because we haven't installed virtualenvwrapper yet; use [`VIRTUALENV_PYTHON`](https://virtualenv.pypa.io/en/latest/reference/#environment-variables) instead.