### PR TITLE
Update diveinto link

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -891,4 +891,4 @@ Further Reading
 ***************
 
 - http://docs.python.org/3/library/
-- https://www.diveinto.org/python3/
+- https://diveintopython3.net/


### PR DESCRIPTION
The diveinto.org link is broken when I try it.  I found that https://diveinto.org/python3/table-of-contents.html works but the https://diveintopython3.net/ is shorter and appears less broken to someone reading the url for the first time.  The table of content at this updated address looks the same as what I found on the web.archive.org for the diveinto.org link.