### PR TITLE
#1021 Moved VS Code to Text Editor

### DIFF
--- a/docs/dev/env.rst
+++ b/docs/dev/env.rst
@@ -138,6 +138,14 @@ Recommended for Python development is
 `Linter <https://github.com/steelbrain/linter>`_ combined with
 `linter-flake8 <https://github.com/AtomLinter/linter-flake8>`_.
 
+Python (on Visual Studio Code)
+------------------------------
+
+`Python for Visual Studio <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ is an extension for the `Visual Studio Code <https://code.visualstudio.com>`_.
+This is a free, lightweight, open source code editor, with support for Mac, Windows, and Linux.
+Built using open source technologies such as Node.js and Python, with compelling features such as Intellisense (autocompletion), local and remote debugging, linting, and the like.
+
+MIT licensed.
 
 IDEs
 ::::
@@ -152,14 +160,6 @@ features can be brought to IntelliJ with the free
 versions of PyCharm: Professional Edition (Free 30-day trial) and Community
 Edition (Apache 2.0 License) with fewer features.
 
-Python (on Visual Studio Code)
-------------------------------
-
-`Python for Visual Studio <https://marketplace.visualstudio.com/items?itemName=ms-python.python>`_ is an extension for the `Visual Studio Code IDE <https://code.visualstudio.com>`_.
-This is a free, lightweight, open source IDE, with support for Mac, Windows, and Linux.
-Built using open source technologies such as Node.js and Python, with compelling features such as Intellisense (autocompletion), local and remote debugging, linting, and the like.
-
-MIT licensed.
 
 Enthought Canopy
 ----------------


### PR DESCRIPTION
As mentioned in #1021 , Visual Studio Code is not an IDE, therefore, moving it from "IDEs" to "Text Editors" and correcting the mis-spellings (e.g.: "Visual Studio Code IDE" to "Visual Studio Code")