### PR TITLE
Update yaml.load() to avoid warning

### DIFF
--- a/docs/scenarios/serialization.rst
+++ b/docs/scenarios/serialization.rst
@@ -130,7 +130,7 @@ structures in Python. One such example is below.
         import yaml
         with open('/tmp/file.yaml', 'r', newline='') as f:
             try:
-                print(yaml.load(f))
+                print(yaml.full_load(f))
             except yaml.YAMLError as ymlexcp:
                 print(ymlexcp)
 


### PR DESCRIPTION
The yaml.load() function call throws the following warning when Loader isn't specified:

"YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details."

The updated default loader avoids arbitrary code execution after issuing a warning, however the warning can be avoided with yaml.load(input, Loader=<loader>) or yaml.<full|safe|unsafe>_load(input).