### PR TITLE
Remove simplejson from guide

### DIFF
--- a/docs/scenarios/json.rst
+++ b/docs/scenarios/json.rst
@@ -5,7 +5,7 @@ JSON
 
 .. image:: /_static/photos/33928819683_97b5c6a184_k_d.jpg
 
-The `json <https://docs.python.org/2/library/json.html>`_ library can parse
+The `json <https://docs.python.org/3/library/json.html>`_ library can parse
 JSON from strings or files. The library parses JSON into a Python dictionary
 or list. It can also convert Python dictionaries or lists into JSON strings.
 
@@ -46,27 +46,3 @@ You can also convert the following to JSON:
 
     print(json.dumps(d))
     '{"first_name": "Guido", "last_name": "Rossum", "titles": ["BDFL", "Developer"]}'
-
-
-**********
-simplejson
-**********
-
-The json library was added to Python in version 2.6.
-If you're using an earlier version of Python, the
-`simplejson <https://simplejson.readthedocs.io/en/latest/>`_ library is
-available via PyPI.
-
-simplejson mimics the json standard library. It is available so that developers
-that use older versions of Python can use the latest features available in the
-json lib.
-
-You can start using simplejson when the json library is not available by
-importing simplejson under a different name:
-
-.. code-block:: python
-
-    import simplejson as json
-
-After importing simplejson as `json`, the above examples will all work as if you
-were using the standard json library.


### PR DESCRIPTION
The simplejson library was only needed for Python 2.5 and earlier.
Update documentation link to Python 3.