### PR TITLE
update brew download link

### DIFF
--- a/docs/starting/install3/osx.rst
+++ b/docs/starting/install3/osx.rst
@@ -50,7 +50,7 @@ your favorite OS X terminal emulator and run
 
 .. code-block:: console
 
-    $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
 The script will explain what changes it will make and prompt you before the
 installation begins.


### PR DESCRIPTION
if you use the older `ruby` command, the brew installer throws the following warning in terminal:
```
Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```

This is the official method for installing homebrew per their [homepage](https://brew.sh/) and this [discussion](https://medium.com/@itchyny/homebrew-installer-in-bash-is-released-335bbc2b9bce)