### PR TITLE
kennethreitzs essay repository-structure-and-python new URL

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -59,7 +59,7 @@ becoming intimately familiar with every nook and cranny. The layout is important
 Sample Repository
 :::::::::::::::::
 
-**tl;dr**: This is what `Kenneth Reitz recommended in 2013 <https://www.kennethreitz.org/essays/repository-structure-and-python>`__.
+**tl;dr**: This is what `Kenneth Reitz recommended in 2013 <https://kennethreitz.org/essays/2013/01/27/repository-structure-and-python>`__.
 
 This repository is `available on
 GitHub <https://github.com/kennethreitz/samplemod>`__.


### PR DESCRIPTION
Kenneth Reitzs essay Repository Structure and Python was moved to https://kennethreitz.org/essays/2013/01/27/repository-structure-and-python

The old URL hit a 404.