### PR TITLE
windows, invoke python as py

### DIFF
--- a/docs/starting/install3/win.rst
+++ b/docs/starting/install3/win.rst
@@ -33,7 +33,7 @@ All supported versions of Python 3 include pip, so just make sure it's up to dat
 
 .. code-block:: doscon
 
-    python -m pip install -U pip
+    py -m pip install -U pip
 
 
 *****************************


### PR DESCRIPTION
when following the guide the command no longer works, you need to use the `py` command instead

https://github.com/microsoft/vscode-docs/issues/3198#issuecomment-554361971