### PR TITLE
Update examples to Python 3 in scrape section

### DIFF
--- a/docs/scenarios/scrape.rst
+++ b/docs/scenarios/scrape.rst
@@ -87,8 +87,8 @@ Let's see what we got exactly:
 
 .. code-block:: python
 
-    print 'Buyers: ', buyers
-    print 'Prices: ', prices
+    print('Buyers: ', buyers)
+    print('Prices: ', prices)
 
 ::
 


### PR DESCRIPTION
Updating python 2 syntax to Python 3 in [scrape section](https://docs.python-guide.org/scenarios/scrape/)

Issue #1091