### PR TITLE
Replacing Tablib fork with the original repo

### DIFF
--- a/docs/writing/reading.rst
+++ b/docs/writing/reading.rst
@@ -43,7 +43,7 @@ reading. Each one of these projects is a paragon of Python coding.
   Requests is an Apache2 Licensed HTTP library, written in Python,
   for human beings.
 
-- `Tablib <https://github.com/kennethreitz/tablib>`_
+- `Tablib <https://github.com/jazzband/tablib>`_
   Tablib is a format-agnostic tabular dataset library, written in Python.
 
 


### PR DESCRIPTION
Link currently points to a tablib fork and not to the original repo (https://github.com/jazzband/tablib). Fork doesn't look maintained and is behind the original repo

Changing link to use https://github.com/jazzband/tablib