### PR TITLE
Update Requests documentation links

### DIFF
--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -156,7 +156,7 @@ when you share your project with others. You should get output similar to this
     Adding requests to Pipfile's [packages]...
     P.S. You have excellent taste! ✨ 🍰 ✨
 
-.. _Requests: http://docs.python-requests.org/en/master/
+.. _Requests: https://requests.readthedocs.io/en/latest/
 
 
 Using installed packages

--- a/docs/scenarios/client.rst
+++ b/docs/scenarios/client.rst
@@ -28,7 +28,7 @@ your URLs, or to form-encode your POST data. Keep-alive and HTTP connection
 pooling are 100% automatic, powered by urllib3, which is embedded within
 Requests.
 
-- `Documentation <http://docs.python-requests.org/en/latest/index.html>`_
+- `Documentation <https://requests.readthedocs.io/en/latest/>`_
 - `PyPi <http://pypi.org/project/requests>`_
 - `GitHub <https://github.com/kennethreitz/requests>`_
 

--- a/docs/scenarios/scrape.rst
+++ b/docs/scenarios/scrape.rst
@@ -28,7 +28,7 @@ lxml and Requests
 `lxml <http://lxml.de/>`_ is a pretty extensive library written for parsing
 XML and HTML documents very quickly, even handling messed up tags in the
 process. We will also be using the
-`Requests <http://docs.python-requests.org/en/latest/>`_ module instead of the
+`Requests <https://requests.readthedocs.io/en/latest/>`_ module instead of the
 already built-in urllib2 module due to improvements in speed and readability.
 You can easily install both using ``pip install lxml`` and
 ``pip install requests``.

--- a/docs/writing/style.rst
+++ b/docs/writing/style.rst
@@ -465,8 +465,7 @@ easy-to-read version of PEP 8 is also available at `pep8.org <http://pep8.org/>`
 
 This is highly recommended reading. The entire Python community does their
 best to adhere to the guidelines laid out within this document. Some project
-may sway from it from time to time, while others may
-`amend its recommendations <http://docs.python-requests.org/en/master/dev/contributing/#kenneth-reitz-s-code-style>`_.
+may sway from it from time to time, while others may amend its recommendations.
 
 That being said, conforming your Python code to PEP 8 is generally a good idea
 and helps make code more consistent when working on projects with other


### PR DESCRIPTION
This is a quick follow up from psf/requests#6140. This PR fixes dead links by moving it to https://requests.readthedocs.io/en/latest/ which will be the primary domain for the project going forward. Please let me know if there are any questions/concerns.