### PR TITLE
Update supported versions in which-python page

### DIFF
--- a/docs/starting/which-python.rst
+++ b/docs/starting/which-python.rst
@@ -127,8 +127,7 @@ expose Python code to other languages in the .NET framework.
 IronPython directly into the Visual Studio development environment, making it
 an ideal choice for Windows developers.
 
-IronPython supports Python 2.7. [#iron_ver]_ IronPython 3 [#iron_ver3]_
-is being developed, but is not ready for use as of September 2020.
+IronPython supports Python 2.7. [#iron_ver]_ IronPython 3 supports Python 3.4. [#iron_ver3]_ 
 
 PythonNet
 ---------
@@ -144,7 +143,7 @@ installations on non-Windows operating systems, such as OS X and
 Linux, to operate within the .NET framework.  It can be run in
 addition to IronPython without conflict.
 
-Pythonnet is compatible with Python 2.7 and 3.5-3.8. [#pythonnet_ver1]_
+Pythonnet is compatible with Python 2.7 and 3.7-3.11. [#pythonnet_ver1]_
 
 .. [#pypy_ver] https://pypy.org/compat.html
 


### PR DESCRIPTION
Updated recommendations in the which-python page based on IronPython and PythonNet documentation.

Page changed preview:
![image](https://github.com/realpython/python-guide/assets/6978748/f0472855-7383-4940-ab19-72fdf62ce512)
![image](https://github.com/realpython/python-guide/assets/6978748/f5884b95-9368-46fd-baa7-f035648f95d6)

Ps.: I found this project helpful for those coming from other 'development stacks' and I think even small changes could be beneficial to keep the project relevant.