### PR TITLE
Update structure.rst

### DIFF
--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -225,7 +225,7 @@ Then, within the individual test modules, import the module like so:
 
 ::
 
-    from .context import sample
+    from context import sample
 
 This will always work as expected, regardless of installation method.
 


### PR DESCRIPTION
if the test file is in the same folder as the `context.py`, then there is no need for the preceding dot when importing context