### PR TITLE
Fixes old website 404 issue

### DIFF
--- a/docs/intro/learning.rst
+++ b/docs/intro/learning.rst
@@ -303,7 +303,7 @@ structures and algorithms. All concepts are illustrated with Python code along
 with interactive samples that can be run directly in the browser.
 
     `Problem Solving with Algorithms and Data Structures
-    <http://www.interactivepython.org/courselib/static/pythonds/index.html>`_
+    <https://runestone.academy/ns/books/published/pythonds/index.html>`_
 
 Programming Collective Intelligence
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes issue #1104
Edited line 306 in docs/intro/learning.rst, links a website with a similar book for problem solving with algorithms and data structures to avoid the previous link's 404 page.