### PR TITLE
fix: remove outdated todo "Blueprint"

### DIFF
--- a/docs/scenarios/admin.rst
+++ b/docs/scenarios/admin.rst
@@ -377,13 +377,6 @@ every time the sshd configuration file is changed.
 For more information, refer to the `Puppet Labs Documentation <http://docs.puppetlabs.com>`_
 
 
-*********
-Blueprint
-*********
-
-.. todo:: Write about Blueprint
-
-
 ********
 Buildout
 ********


### PR DESCRIPTION
If Zope Blueprint project was what was gonna be written here, it's largely abandoned. Removed the Blueprint section as a whole