### PR TITLE
docs: update kennethreitz.org outdated links

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 Be cordial or be on your way.
 
-https://www.kennethreitz.org/essays/be-cordial-or-be-on-your-way
+https://kennethreitz.org/essays/2013/be_cordial_or_be_on_your_way

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ master_doc = 'index'
 # General information about the project.
 current_year = datetime.datetime.now().year
 project = u'pythonguide'
-copyright = (u'2011-{} <a href="https://www.kennethreitz.org/projects">Kenneth Reitz</a>'
+copyright = (u'2011-{} <a href="https://kennethreitz.org/software/">Kenneth Reitz</a>'
              ' &amp; <a href="https://realpython.com">Real Python</a>.'
              ' <a href="http://creativecommons.org/licenses/by-nc-sa/3.0/">CC BY-NC-SA 3.0</a>').format(current_year)
 

--- a/docs/dev/virtualenvs.rst
+++ b/docs/dev/virtualenvs.rst
@@ -101,7 +101,7 @@ Use ``pip`` to install Pipenv:
     user ``PATH`` permanently in the `Control Panel`_. You may need to log
     out for the ``PATH`` changes to take effect.
 
-.. _Pipenv: https://pipenv.kennethreitz.org/
+.. _Pipenv: https://kennethreitz.org/software/pipenv
 .. _npm: https://www.npmjs.com/
 .. _bundler: http://bundler.io/
 .. _user base: https://docs.python.org/3/library/site.html#site.USER_BASE

--- a/docs/writing/structure.rst
+++ b/docs/writing/structure.rst
@@ -59,7 +59,7 @@ becoming intimately familiar with every nook and cranny. The layout is important
 Sample Repository
 :::::::::::::::::
 
-**tl;dr**: This is what `Kenneth Reitz recommended in 2013 <https://kennethreitz.org/essays/2013/01/27/repository-structure-and-python>`__.
+**tl;dr**: This is what `Kenneth Reitz recommended in 2013 <https://kennethreitz.org/essays/2013/repository_structure_and_python>`__.
 
 This repository is `available on
 GitHub <https://github.com/kennethreitz/samplemod>`__.


### PR DESCRIPTION
# docs: update kennethreitz.org outdated links
*Verify external Kenneth Reitz URLs in documentation*

## Summary
This PR fixes outdated (404 not found) for all references to https://kennethreitz.org/ in the built Sphinx HTML documentation. The goal is to ensure that all external links are reachable and return a successful HTTP response.

## Verification

- Built the documentation in a clean Docker environment using Python 3.7:
```bash
docker run -it -p 8000:8000 -v $PWD:/app -w /app python:3.7 bash
pip install --upgrade pip
pip install sphinx
cd docs
make html
sphinx-build -b html -d _build/doctrees . _build/html
```

- **Grepped all Kenneth Reitz URLs from the built HTML**:
```bash
grep -HoR "https://kennethreitz.org/[^\"'<> ]*" /app/docs/_build/html | cut -d':' -f2- | sort -u
```

- **Unique URLs found**:
    - https://kennethreitz.org/essays/2013/repository_structure_and_python
    -https://kennethreitz.org/software/
    -https://kennethreitz.org/software/pipenv

- **Verified accessibility with HTTP HEAD requests using** `curl -I`:
```bash
grep -HoR "https://kennethreitz.org/[^\"'<> ]*" /app/docs/_build/html \
  | cut -d':' -f2- \
  | sort -u \
  | xargs -n 1 curl -I

HTTP/2 200 
server: Fly/240521282 (2025-08-19)
date: Tue, 19 Aug 2025 20:49:15 GMT
content-type: text/html; charset=utf-8
content-length: 137640
via: 2 fly.io, 2 fly.io
fly-request-id: 01K321FQDBDM6CX295E6WEF305-cdg

HTTP/2 200 
server: Fly/240521282 (2025-08-19)
date: Tue, 19 Aug 2025 20:49:15 GMT
content-type: text/html; charset=utf-8
content-length: 134215
via: 2 fly.io, 2 fly.io
fly-request-id: 01K321FQQ2X3HH82S4GGWKTJ07-cdg

HTTP/2 200 
server: Fly/240521282 (2025-08-19)
date: Tue, 19 Aug 2025 20:49:15 GMT
content-type: text/html; charset=utf-8
content-length: 129003
via: 2 fly.io, 2 fly.io
fly-request-id: 01K321FR06WPX9X6XKQEKQTNT6-cdg
```

- **Results**

✅ All referenced Kenneth Reitz URLs are reachable and return HTTP 200.
- Documentation links referring to kennethreitz.org are safe to keep; no broken links detected.